### PR TITLE
fixed issue 46: the TG stickerpack deserialisation issue

### DIFF
--- a/mstickerlib/src/tg/stickerpack.rs
+++ b/mstickerlib/src/tg/stickerpack.rs
@@ -16,8 +16,6 @@ use log::{info, warn};
 pub struct StickerPack {
 	pub(crate) name: String,
 	pub(crate) title: String,
-	pub(crate) is_animated: bool,
-	pub(crate) is_video: bool,
 	pub(crate) stickers: Vec<Sticker>
 }
 
@@ -51,12 +49,6 @@ impl StickerPack {
 		#[cfg(feature = "log")]
 		if log::log_enabled!(log::Level::Info) {
 			let mut output = "".to_owned();
-			if self.is_animated {
-				output += " animations";
-			}
-			if self.is_video {
-				output += " videos";
-			}
 			if !output.is_empty() {
 				output = format!(", include:{output}");
 			}


### PR DESCRIPTION
The result of current version of`getStickerSet` don't have `is_animated` and `is_video` field.
Thus, the v0.3.3 version are failed to import any Telegram stickers due to the deserialisation of `result` failed  (#46) .

```JSONC
//Below is the current version of API result
{
    "ok": true,
    "result": {
        "name": "GumLoveIs",
        "title": "LIHKG Lomore",
        "thumbnail": {},
        "thumb": {},
        "sticker_type": "regular",
        "contains_masks": false,
        "stickers": []
    }
}
```