### PR TITLE
fixed the matrix login issue caused by whoami function

### DIFF
--- a/mstickerlib/src/matrix/mod.rs
+++ b/mstickerlib/src/matrix/mod.rs
@@ -155,7 +155,7 @@ pub async fn set_widget(matrix: &Config, sender: String, url: String) -> Result<
 	Ok(())
 }
 
-pub async fn whoami(matrix: &Config) -> Result<Mxc, Error> {
+pub async fn whoami(matrix: &Config) -> Result<Whoami, Error> {
 	Url::parse(&matrix.homeserver_url)?; //check if homeserver_url is a valid url
 	let answer = CLIENT
 		.get()


### PR DESCRIPTION
Currently, the response of Matrix `whoami` API call are deserialised into MXC object.
Due to this deserialisation issue, `mstickereditor` always return below error:

```sh
Error connecting to Matrix homeserver: Reqwest(reqwest::Error { kind: Decode, source: Error("invalid type: map, expected a string", line: 1, column: 0) })
```

And I tested that entire project is working again after fixing this issue.