### PR TITLE
quick fix for gif conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ homeserver_url = "https://matrix-client.matrix.org"
 access_token = "YOUR-MATIRX-ACESSTOKEN"
 
 [sticker]
-transparent_color = { r = 0, g = 0, b = 0, alpha = true }
+transparent_color = { r = 0, g = 0, b = 0, a = true }
 animation_format = "webp"
 ```
 The `[sticker]` section is optional and can be left out.

--- a/mstickereditor/src/sub_commands/import.rs
+++ b/mstickereditor/src/sub_commands/import.rs
@@ -60,6 +60,7 @@ pub async fn run(mut opt: Opt) -> anyhow::Result<()> {
 	import_config.dry_run = opt.dryrun;
 	import_config.keep_webm = opt.keep_webm;
 	import_config.keep_lottie = opt.keep_lottie;
+	import_config.animation_format = config.sticker;
 	let import_config = import_config;
 	let mut empty_packs = Vec::new();
 


### PR DESCRIPTION
`animation_format` in config file is not being used. So even set to `gif`, the finally sticker format are still webp. And Lottie conversion is not involved. 

and `a` is the expected key for `gif` reba colour, not `alpha`.