### PR TITLE
Fix synapse rejecting media upload

### DIFF
--- a/mstickerlib/src/matrix/mod.rs
+++ b/mstickerlib/src/matrix/mod.rs
@@ -135,7 +135,7 @@ pub async fn set_widget(matrix: &Config, sender: String, url: String) -> Result<
 	let answer = CLIENT
 		.get()
 		.put(format!(
-			"{}/_matrix/client/r0/user/{}/account_data/m.widgets",
+			"{}/_matrix/client/v3/user/{}/account_data/m.widgets",
 			matrix.homeserver_url, matrix.user
 		))
 		.query(&[("access_token", &matrix.access_token)])
@@ -159,7 +159,7 @@ pub async fn whoami(matrix: &Config) -> Result<Whoami, Error> {
 	Url::parse(&matrix.homeserver_url)?; //check if homeserver_url is a valid url
 	let answer = CLIENT
 		.get()
-		.get(format!("{}/_matrix/client/r0/account/whoami", matrix.homeserver_url))
+		.get(format!("{}/_matrix/client/v3/account/whoami", matrix.homeserver_url))
 		.query(&[("access_token", &matrix.access_token)])
 		.send()
 		.await?;
@@ -185,7 +185,7 @@ pub(crate) async fn upload(matrix: &Config, filename: &String, data: Arc<Vec<u8>
 pub(crate) async fn upload_ref(matrix: &Config, filename: &String, data: &[u8], mimetype: &str) -> Result<Mxc, Error> {
 	let answer = CLIENT
 		.get()
-		.post(&format!("{}/_matrix/media/r0/upload", matrix.homeserver_url))
+		.post(&format!("{}/_matrix/media/v3/upload", matrix.homeserver_url))
 		.query(&[("access_token", &matrix.access_token), ("filename", filename)])
 		.header("Content-Type", mimetype)
 		.body(data.to_owned()) //TODO check for better solution

--- a/mstickerlib/src/matrix/mod.rs
+++ b/mstickerlib/src/matrix/mod.rs
@@ -196,9 +196,10 @@ where
 		.unwrap_or_else(|| path.as_os_str())
 		.to_str()
 		.expect("Not valid UTF-8");
+	let slash = if matrix.homeserver_url.ends_with('/') { "" } else { "/" };
 	let answer = CLIENT
 		.get()
-		.post(&format!("{}/_matrix/media/v3/upload", matrix.homeserver_url))
+		.post(&format!("{}{slash}_matrix/media/v3/upload", matrix.homeserver_url))
 		.query(&[("access_token", matrix.access_token.as_str()), ("filename", filename)])
 		.header("Content-Type", mimetype)
 		.body(data.to_owned()) //TODO check for better solution

--- a/mstickerlib/src/matrix/mod.rs
+++ b/mstickerlib/src/matrix/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
 	fmt::{Debug, Display},
 	ops::Deref,
+	path::Path,
 	sync::Arc
 };
 use stickerpicker::StickerWidget;
@@ -176,17 +177,29 @@ pub async fn whoami(matrix: &Config) -> Result<Whoami, Error> {
 	}
 }
 
-pub(crate) async fn upload(matrix: &Config, filename: &String, data: Arc<Vec<u8>>, mimetype: &str) -> Result<Mxc, Error> {
-	let mut mxc = upload_ref(matrix, filename, data.as_slice(), mimetype).await?;
+pub(crate) async fn upload<P>(matrix: &Config, path: P, data: Arc<Vec<u8>>, mimetype: &str) -> Result<Mxc, Error>
+where
+	P: AsRef<Path>
+{
+	let mut mxc = upload_ref(matrix, path, data.as_slice(), mimetype).await?;
 	mxc.data = Some(data);
 	Ok(mxc)
 }
 
-pub(crate) async fn upload_ref(matrix: &Config, filename: &String, data: &[u8], mimetype: &str) -> Result<Mxc, Error> {
+pub(crate) async fn upload_ref<P>(matrix: &Config, path: P, data: &[u8], mimetype: &str) -> Result<Mxc, Error>
+where
+	P: AsRef<Path>
+{
+	let path = path.as_ref();
+	let filename = path
+		.file_name()
+		.unwrap_or_else(|| path.as_os_str())
+		.to_str()
+		.expect("Not valid UTF-8");
 	let answer = CLIENT
 		.get()
 		.post(&format!("{}/_matrix/media/v3/upload", matrix.homeserver_url))
-		.query(&[("access_token", &matrix.access_token), ("filename", filename)])
+		.query(&[("access_token", matrix.access_token.as_str()), ("filename", filename)])
 		.header("Content-Type", mimetype)
 		.body(data.to_owned()) //TODO check for better solution
 		.send()


### PR DESCRIPTION
It's probably just the last change (i.e. preventing `//` in the url) and it should be done not only for upload but for all http requests. But the other two changes are probably also good (but possibly breaking changes regarding semver).